### PR TITLE
Use volume name as volume path

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -36,12 +36,7 @@ func (d ipfsDriver) Create(r volume.Request) volume.Response {
 		return volume.Response{}
 	}
 
-	hash, ok := r.Options["hash"]
-	if !ok {
-		return volume.Response{Err: "Cannot find 'hash' option"}
-	}
-
-	volumePath := filepath.Join(d.mountPoint, hash)
+	volumePath := filepath.Join(d.mountPoint, volumeName)
 
 	_, err := os.Lstat(volumePath)
 	if err != nil {


### PR DESCRIPTION
This PR allows to use directly volume name as volume path:

```
$ docker run -it --rm -v QmPXME1oRtoT627YKaDPDQ3PwA8tdP9rWuAAweLzqSwAWT/readme:/data --volume-driver=ipfs busybox cat data
Hello and Welcome to IPFS!

██╗██████╗ ███████╗███████╗
██║██╔══██╗██╔════╝██╔════╝
██║██████╔╝█████╗  ███████╗
██║██╔═══╝ ██╔══╝  ╚════██║
██║██║     ██║     ███████║
╚═╝╚═╝     ╚═╝     ╚══════╝

If you're seeing this, you have successfully installed
IPFS and are now interfacing with the ipfs merkledag!

 -------------------------------------------------------
| Warning:                                              |
|   This is alpha software. use at your own discretion! |
|   Much is missing or lacking polish. There are bugs.  |
|   Not yet secure. Read the security notes for more.   |
 -------------------------------------------------------

Check out some of the other files in this directory:

  ./about
  ./help
  ./quick-start     <-- usage examples
  ./readme          <-- this file
  ./security-notes
```
