### PR TITLE
Add 1.10 support

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -91,3 +91,26 @@ func (d ipfsDriver) Unmount(r volume.Request) volume.Response {
 	fmt.Printf("Unmount %v: nothing to do\n", r)
 	return volume.Response{}
 }
+
+func (d ipfsDriver) Get(r volume.Request) volume.Response {
+	fmt.Printf("Get %v\n", r)
+	volumeName := r.Name
+
+	if volumePath, ok := d.volumes[volumeName]; ok {
+		return volume.Response{Volume: &volume.Volume{Name: volumeName, Mountpoint: volumePath}}
+	}
+
+	return volume.Response{Err: fmt.Sprintf("volume %s does not exists", volumeName)}
+}
+
+func (d ipfsDriver) List(r volume.Request) volume.Response {
+	fmt.Printf("List %v\n", r)
+
+	volumes := []*volume.Volume{}
+
+	for name, path := range d.volumes {
+		volumes = append(volumes, &volume.Volume{Name: name, Mountpoint: path})
+	}
+
+	return volume.Response{Volumes: volumes}
+}

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -5,7 +5,7 @@ cd "$(dirname "$BASH_SOURCE")/.."
 rm -rf vendor/
 source 'hack/.vendor-helpers.sh'
 
-clone git github.com/docker/go-plugins-helpers c673bfc017b81d1dd62b922fdc8672a42dd28226
+clone git github.com/docker/go-plugins-helpers 2bce64a6080c74e6eb388aab8da36067cd33ca08
 clone git github.com/docker/go-connections 64a666f8c9ca9539fe05fc36fab9ccc257bcbc55
 clone git github.com/Sirupsen/logrus v0.8.7 # logrus is a common dependency among multiple deps
 clone git github.com/opencontainers/runc 3d8a20bb772defc28c355534d83486416d1719b4

--- a/vendor/github.com/docker/go-plugins-helpers/sdk/handler.go
+++ b/vendor/github.com/docker/go-plugins-helpers/sdk/handler.go
@@ -24,7 +24,16 @@ func NewHandler(manifest string) Handler {
 		fmt.Fprintln(w, manifest)
 	})
 
-	return Handler{mux}
+	return Handler{mux: mux}
+}
+
+// Serve sets up the handler to serve requests on the passed in listener
+func (h Handler) Serve(l net.Listener) error {
+	server := http.Server{
+		Addr:    l.Addr().String(),
+		Handler: h.mux,
+	}
+	return server.Serve(l)
 }
 
 // ServeTCP makes the handler to listen for request in a given TCP address.
@@ -46,9 +55,9 @@ func (h Handler) HandleFunc(path string, fn func(w http.ResponseWriter, r *http.
 
 func (h Handler) listenAndServe(proto, addr, group string) error {
 	var (
-		l    net.Listener
 		err  error
 		spec string
+		l    net.Listener
 	)
 
 	server := http.Server{

--- a/vendor/github.com/docker/go-plugins-helpers/volume/api.go
+++ b/vendor/github.com/docker/go-plugins-helpers/volume/api.go
@@ -12,7 +12,9 @@ const (
 
 	manifest        = `{"Implements": ["VolumeDriver"]}`
 	createPath      = "/VolumeDriver.Create"
-	remotePath      = "/VolumeDriver.Remove"
+	getPath         = "/VolumeDriver.Get"
+	listPath        = "/VolumeDriver.List"
+	removePath      = "/VolumeDriver.Remove"
 	hostVirtualPath = "/VolumeDriver.Path"
 	mountPath       = "/VolumeDriver.Mount"
 	unmountPath     = "/VolumeDriver.Unmount"
@@ -28,11 +30,21 @@ type Request struct {
 type Response struct {
 	Mountpoint string
 	Err        string
+	Volumes    []*Volume
+	Volume     *Volume
+}
+
+// Volume represents a volume object for use with `Get` and `List` requests
+type Volume struct {
+	Name       string
+	Mountpoint string
 }
 
 // Driver represent the interface a driver must fulfill.
 type Driver interface {
 	Create(Request) Response
+	List(Request) Response
+	Get(Request) Response
 	Remove(Request) Response
 	Path(Request) Response
 	Mount(Request) Response
@@ -59,7 +71,15 @@ func (h *Handler) initMux() {
 		return h.driver.Create(req)
 	})
 
-	h.handle(remotePath, func(req Request) Response {
+	h.handle(getPath, func(req Request) Response {
+		return h.driver.Get(req)
+	})
+
+	h.handle(listPath, func(req Request) Response {
+		return h.driver.List(req)
+	})
+
+	h.handle(removePath, func(req Request) Response {
 		return h.driver.Remove(req)
 	})
 


### PR DESCRIPTION
Support for `Get` and `List` endpoint. This make it support 1.10 updates on volume plugins 🐮.

``` bash
$ docker volume create --driver ipfs --name QmPXME1oRtoT627YKaDPDQ3PwA8tdP9rWuAAweLzqSwAWT
$ docker volume ls
DRIVER              VOLUME NAME
local               d2e5df7d41466d7555bdfaa91048943384ca8195b34f9527f9cf8497f8f0fc50
ipfs                QmPXME1oRtoT627YKaDPDQ3PwA8tdP9rWuAAweLzqSwAWT

```

Closes #7 

🐸
