### PR TITLE
Add more options to the volume plugin.

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -10,16 +10,18 @@ import (
 )
 
 type ipfsDriver struct {
-	mountPoint string
-	volumes    map[string]string
-	m          *sync.Mutex
+	ipfsMountPoint string
+	ipnsMountPoint string
+	volumes        map[string]string
+	m              *sync.Mutex
 }
 
-func newIPFSDriver(ipfsMountPoint string) ipfsDriver {
+func newIPFSDriver(ipfsMountPoint, ipnsMountPoint string) ipfsDriver {
 	d := ipfsDriver{
-		mountPoint: ipfsMountPoint,
-		volumes:    make(map[string]string),
-		m:          &sync.Mutex{},
+		ipfsMountPoint: ipfsMountPoint,
+		ipnsMountPoint: ipnsMountPoint,
+		volumes:        make(map[string]string),
+		m:              &sync.Mutex{},
 	}
 	return d
 }
@@ -36,7 +38,7 @@ func (d ipfsDriver) Create(r volume.Request) volume.Response {
 		return volume.Response{}
 	}
 
-	volumePath := filepath.Join(d.mountPoint, volumeName)
+	volumePath := filepath.Join(d.ipfsMountPoint, volumeName)
 
 	_, err := os.Lstat(volumePath)
 	if err != nil {

--- a/ipfs/ipfs.go
+++ b/ipfs/ipfs.go
@@ -1,0 +1,112 @@
+package ipfs
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// Daemon represent the ipfs daemon (to run) and options for it.
+type Daemon struct {
+	init bool
+	path string
+	cmd  *exec.Cmd
+}
+
+// NewDaemon returns a new instance of IPFSDaemon.
+func NewDaemon(init bool, path string) *Daemon {
+	return &Daemon{
+		init: init,
+		path: path,
+	}
+}
+
+// Setup sets the daemon up, initializing ipfs if asked and making sure that
+// fuse allow_other is true (otherwise it is not gonna work — permission denied).
+func (d *Daemon) Setup() error {
+	if d.init {
+		cmd := prepareIPFSCommand(d.path, "init")
+		out, err := cmd.CombinedOutput()
+		if err != nil && !strings.Contains(string(out), "ipfs configuration file already exists!") {
+			fmt.Fprintf(os.Stderr, "%s", out)
+			return err
+		}
+	}
+	// Make sure fuse config allow others
+	// ipfs config --json Mounts.FuseAllowOther true
+	cmd := prepareIPFSCommand(d.path, "config", "--json", "Mounts.FuseAllowOther", "true")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s", out)
+	}
+	return err
+}
+
+// Start starts the IPFS daemon with mount option.
+func (d *Daemon) Start() error {
+	cmd := prepareIPFSCommand(d.path, "daemon", "--mount")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error creating StdoutPipe for IPFS", err)
+		os.Exit(1)
+	}
+
+	scannerOut := bufio.NewScanner(stdout)
+	go func() {
+		for scannerOut.Scan() {
+			fmt.Printf("IPFS > %s\n", scannerOut.Text())
+		}
+	}()
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error creating StderrPipe for IPFS", err)
+		os.Exit(1)
+	}
+
+	scannerErr := bufio.NewScanner(stderr)
+	go func() {
+		for scannerErr.Scan() {
+			fmt.Printf("IPFS > %s\n", scannerErr.Text())
+		}
+	}()
+
+	err = cmd.Start()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error starting IPFS", err)
+		os.Exit(1)
+	}
+
+	d.cmd = cmd
+	return nil
+}
+
+// Stop kills the daemon
+// FIXME(vdemeester): It seems it's not that easy to kill ipfs
+func (d *Daemon) Stop(sig os.Signal) error {
+	if d.cmd != nil {
+		// return d.cmd.Process.Signal(sig)
+		return d.cmd.Process.Kill()
+	}
+	return nil
+}
+
+func prepareIPFSCommand(path string, args ...string) *exec.Cmd {
+	cmd := exec.Command("ipfs", args...)
+	if path != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("IPFS_PATH=%s", path))
+	}
+	return cmd
+}
+
+// ReadConfig reads configuration key for the specified config path.
+func ReadConfig(configPath, key string) (string, error) {
+	cmd := prepareIPFSCommand(configPath, "config", key)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s", out)
+	}
+	return string(out), err
+}


### PR DESCRIPTION
Add more options when running the volume plugin 🐙. Closes #10.
- `daemon` and `daemon-init` to specify if we want to start the daemon or
  not _and_ if we want to init or not the ipfs configuration.
  
  When starting the daemon, by default it will try to init it (`ipfs init`)
  before running it. It will also make sure `Mounts.FuseAllowOther` is
  true in order to make the volume readable inside containers.
- `ipfs-config` to specify the config path to use. It is used when
  starting the daemon and to detect `ipfs` and `ipns` mount point.

🐸
